### PR TITLE
Add the `omitTrailingSlashes` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# metalsmith-sitemap
+# metalsmith-canonical
 [![npm version][npm-badge]][npm-url]
 [![Build Status][travis-badge]][travis-url]
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ A [multimatch](https://github.com/sindresorhus/multimatch) pattern. Only for fil
 
 Will replace any paths ending in `index.html` with `''`. Useful when you're using [metalsmith-permalinks](https://github.com/segmentio/metalsmith-permalinks).
 
+##### omitTrailingSlashes
+
+* `optional`
+* `default: true`
+
+Will remove any trailing slashes.
+
 ## License
 
 ISC

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const multimatch  = require('multimatch');
 module.exports = function canonical(options) {
   options = options || {};
   options.omitIndex = !!options.omitIndex;
+  options.omitTrailingSlashes = _.isUndefined(options.omitTrailingSlashes) ? true : options.omitTrailingSlashes;
   options.pattern = options.pattern || '**/*.html';
 
   return function(files, metalsmith, done) {
@@ -21,13 +22,19 @@ module.exports = function canonical(options) {
 
     // Builds a url
     function buildUrl(file) {
-      // Remove index.html if necessary
+      let url = file;
+
       if (options.omitIndex) {
-        return omitTrailingSlashes(joinUrl(options.hostname, replaceBackslash(_.trimEnd(file, 'index.html'))));
+        url = _.trimEnd(url, 'index.html')
       }
 
-      // Otherwise just use 'file'
-      return omitTrailingSlashes(joinUrl(options.hostname, replaceBackslash(file)));
+      url = joinUrl(options.hostname, replaceBackslash(url));
+
+      if (options.omitTrailingSlashes) {
+        url = omitTrailingSlashes(url);
+      }
+
+      return url;
     }
 
     function replaceBackslash(url) {

--- a/test/fixtures/omit-trailing-slashes/src/index.html
+++ b/test/fixtures/omit-trailing-slashes/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+ <meta charset="UTF-8">
+ <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,27 @@ describe('metalsmith-canonical', function() {
       .build(done);
   });
 
+  it('should omit tailing slashes if set to true', function(done) {
+    Metalsmith('test/fixtures/omit-trailing-slashes')
+      .use(canonical({ hostname: 'http://www.website.com/', omitTrailingSlashes: true, omitIndex: true }))
+      .use(expectFile('index.html', f => expect(f.canonical).to.equal('http://www.website.com')))
+      .build(done);
+  });
+
+  it('should not omit tailing slashes if set to false', function(done) {
+    Metalsmith('test/fixtures/omit-trailing-slashes')
+      .use(canonical({ hostname: 'http://www.website.com/', omitTrailingSlashes: false, omitIndex: true }))
+      .use(expectFile('index.html', f => expect(f.canonical).to.equal('http://www.website.com/')))
+      .build(done);
+  });
+
+  it('should omit tailing slashes by default', function(done) {
+    Metalsmith('test/fixtures/omit-trailing-slashes')
+      .use(canonical({ hostname: 'http://www.website.com/', omitIndex: true }))
+      .use(expectFile('index.html', f => expect(f.canonical).to.equal('http://www.website.com')))
+      .build(done);
+  });
+
   it('should not override existing canonical property', function(done) {
     Metalsmith('test/fixtures/override')
       .use(canonical({ hostname: 'http://www.website.com/' }))


### PR DESCRIPTION
This option allows users to leave trailing slashes at the end of
their canonical URLs.

The option is set to true by default, and that was the default
behaviour before, so there is no breaking change.