### PR TITLE
Fix: Omit `index.html` Even If It's in the Root of All Files

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function canonical(options) {
 
     function omitIndex(url) {
 
-      return url.replace(/[/\\]index\.[^/\\]*$/, '/');
+      return url.replace(/(^|[/\\])index\.[^/\\]*$/, '$1');
     }
 
     function omitExtensions(url, extensionsToOmit) {

--- a/test/metalsmith-canonical.js
+++ b/test/metalsmith-canonical.js
@@ -122,6 +122,25 @@ describe('metalsmith-canonical', function() {
     });
   });
 
+  it('should omit "index.html" if it\'s in the root', () => {
+    const canonical = metalsmithCanonical({
+      hostname: 'http://localhost:8080',
+      omitIndex: true,
+    });
+
+    const files = {
+      'index.html': {}
+    };
+
+    canonical(files, {}, () => {});
+
+    expect(files).to.deep.equal({
+      'index.html': {
+        canonical: 'http://localhost:8080'
+      }
+    });
+  });
+
   it('should omit only exact matches of "index.html"', () => {
     const canonical = metalsmithCanonical({
       hostname: 'http://localhost:8080',


### PR DESCRIPTION
Fix bug: if file path is `index.html` then index is not omitted despite `omitIndex` option.
Should be more clear from the test added.